### PR TITLE
Point links to newer RFC 7946 specification

### DIFF
--- a/geojson-geometry.apib
+++ b/geojson-geometry.apib
@@ -1,6 +1,6 @@
 # GeoJSON Geometry Objects
 
-This API Bluperint defines some of the [GeoJSON Geometry Objects](http://geojson.org/geojson-spec.html#geometry-objects).
+This API Bluperint defines some of the [GeoJSON Geometry Objects](https://tools.ietf.org/html/rfc7946#section-3.1).
 
 After transcluding this bluperint you can uses Geometry objects in your API Blueprint like so:
 
@@ -15,7 +15,7 @@ After transcluding this bluperint you can uses Geometry objects in your API Blue
 ## Geometry (object)
 A geometry is a GeoJSON object where the type member's value is one of the following strings: "Point", "MultiPoint", "LineString", "MultiLineString", "Polygon", "MultiPolygon", or "GeometryCollection".
 
-<http://geojson.org/geojson-spec.html#geometry-objects>
+<https://tools.ietf.org/html/rfc7946#section-3.1>
 
 ### Properties
 - type (string, required) - Type of the geometry.


### PR DESCRIPTION
From http://geojson.org :

> In 2015, the Internet Engineering Task Force (IETF), in conjunction with the original specification authors, formed a GeoJSON WG to standardize GeoJSON. RFC 7946 was published in August 2016 and is the new standard specification of the GeoJSON format, replacing the 2008 GeoJSON specification.